### PR TITLE
reboot counter sensor

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,6 +82,9 @@ func main() {
 	board := probers.NewBoardMonitor()
 	board.Start(boardAddress, reportCh)
 
+	reboot := probers.NewRebootCounter()
+	reboot.Start(reportCh)
+
 	if conf.VMSensor {
 		virtualMemorySensor := sensors.NewSensor(sensors.NewVirtualMemorySensor(time.Minute), "Disk Sensor", reportCh)
 		virtualMemorySensor.Start()

--- a/probers/get_daily_reboots.go
+++ b/probers/get_daily_reboots.go
@@ -40,8 +40,7 @@ func (rebootCounter *RebootCounter) Start(inCh chan *measure.Measure) {
 
 // GetReboots This function runs reboots.sh which returns the number of reboots for the current day
 func GetReboots() int64 {
-	cmd, err := exec.Command("./reboots.sh").Output()
-	fmt.Println("REBOOTS: ", string(cmd))
+	cmd, err := exec.Command("./probers/reboots.sh").Output()
 	if err != nil {
 		fmt.Printf("Error trying to get # of reboots: %v\n", err)
 		return 100
@@ -51,6 +50,5 @@ func GetReboots() int64 {
 		fmt.Printf("Error parsing system response: %v\n", err)
 		return 100
 	}
-	//fmt.Printf("Number of reboots today: %v\n", reboots)
 	return int64(reboots)
 }

--- a/probers/get_daily_reboots.go
+++ b/probers/get_daily_reboots.go
@@ -3,7 +3,6 @@
 package probers
 
 import (
-	"bytes"
 	"fmt"
 	"hostmonitor/measure"
 	"os/exec"
@@ -41,18 +40,13 @@ func (rebootCounter *RebootCounter) Start(inCh chan *measure.Measure) {
 
 // GetReboots This function runs reboots.sh which returns the number of reboots for the current day
 func GetReboots() int64 {
-	var cmd = exec.Command("bash", "./reboots.sh")
-	var out bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &stderr
-	err := cmd.Run()
+	cmd, err := exec.Command("./reboots.sh").Output()
+	fmt.Println("REBOOTS: ", string(cmd))
 	if err != nil {
 		fmt.Printf("Error trying to get # of reboots: %v\n", err)
 		return 100
 	}
-	time.Sleep(10 * time.Millisecond)
-	reboots, err := strconv.Atoi(strings.Split(out.String(), "\n")[0])
+	reboots, err := strconv.Atoi(strings.Split(string(cmd), "\n")[0])
 	if err != nil {
 		fmt.Printf("Error parsing system response: %v\n", err)
 		return 100

--- a/probers/get_daily_reboots_linux_macOS.go
+++ b/probers/get_daily_reboots_linux_macOS.go
@@ -1,0 +1,62 @@
+//go:build linux || darwin
+
+package probers
+
+import (
+	"bytes"
+	"fmt"
+	"hostmonitor/measure"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type RebootCounter struct {
+	reboots int64
+}
+
+func NewRebootCounter() *RebootCounter {
+	rebootCounter := new(RebootCounter)
+	rebootCounter.reboots = 0
+	return rebootCounter
+}
+
+func (rebootCounter *RebootCounter) Start(inCh chan *measure.Measure) {
+	fmt.Printf("Starting reboot counter...\n")
+	ticker := time.NewTicker(60 * time.Second)
+	go func() {
+		for range ticker.C {
+			rebootCounter.reboots = GetReboots()
+			m := &measure.Measure{
+				Strings:  make(map[string]string),
+				Integers: make(map[string]int64),
+				Doubles:  make(map[string]float64),
+			}
+			m.Integers["Reboots_Today"] = rebootCounter.reboots
+			inCh <- m
+		}
+	}()
+}
+
+// GetReboots This function runs reboots.sh which returns the number of reboots for the current day
+func GetReboots() int64 {
+	var cmd = exec.Command("bash", "./reboots.sh")
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		fmt.Printf("Error trying to get # of reboots: %v\n", err)
+		return 100
+	}
+	time.Sleep(10 * time.Millisecond)
+	reboots, err := strconv.Atoi(strings.Split(out.String(), "\n")[0])
+	if err != nil {
+		fmt.Printf("Error parsing system response: %v\n", err)
+		return 100
+	}
+	//fmt.Printf("Number of reboots today: %v\n", reboots)
+	return int64(reboots)
+}

--- a/probers/get_daily_reboots_windows.go
+++ b/probers/get_daily_reboots_windows.go
@@ -38,7 +38,7 @@ func (rebootCounter *RebootCounter) Start(inCh chan *measure.Measure) {
 	}()
 }
 
-// GetReboots This function runs reboots.sh which returns the number of reboots for the current day
+// GetReboots
 func GetReboots() int64 {
 	c1 := "day=$(Get-Date)"
 	c2 := "log=$(Get-WinEvent -FilterHashtable @{LogName = 'System';id=6006; StartTime=$day})"

--- a/probers/get_daily_reboots_windows.go
+++ b/probers/get_daily_reboots_windows.go
@@ -1,0 +1,61 @@
+//go:build windows
+
+package probers
+
+import (
+	"fmt"
+	"hostmonitor/measure"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type RebootCounter struct {
+	reboots int64
+}
+
+func NewRebootCounter() *RebootCounter {
+	rebootCounter := new(RebootCounter)
+	rebootCounter.reboots = 0
+	return rebootCounter
+}
+
+func (rebootCounter *RebootCounter) Start(inCh chan *measure.Measure) {
+	fmt.Printf("Starting reboot counter...\n")
+	ticker := time.NewTicker(60 * time.Second)
+	go func() {
+		for _ = range ticker.C {
+			rebootCounter.reboots = GetReboots()
+			m := &measure.Measure{
+				Strings:  make(map[string]string),
+				Integers: make(map[string]int64),
+				Doubles:  make(map[string]float64),
+			}
+			m.Integers["Reboots_Today"] = rebootCounter.reboots
+			inCh <- m
+		}
+	}()
+}
+
+// GetReboots This function runs reboots.sh which returns the number of reboots for the current day
+func GetReboots() int64 {
+	c1 := "day=$(Get-Date)"
+	c2 := "log=$(Get-WinEvent -FilterHashtable @{LogName = 'System';id=6006; StartTime=$day})"
+	c3 := "\"$log\".Count"
+	cmd := exec.Command("powershell.exe", "-c", "chcp", "65001", ">", "$null", ";", c1)
+	cmd = exec.Command("powershell.exe", "-c", "chcp", "65001", ">", "$null", ";", c2)
+	cmd = exec.Command("powershell.exe", "-c", "chcp", "65001", ">", "$null", ";", c3)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("Error trying to get # of reboots: %v\n", err)
+		return 100
+	}
+	reboots, err := strconv.Atoi(strings.Split(string(out), "\r\n")[0])
+	if err != nil {
+		fmt.Printf("Error parsing system response: %v\n", err)
+		return 100
+	}
+	//fmt.Printf("Number of reboots today: %v\n", reboots)
+	return int64(reboots)
+}

--- a/probers/reboots.sh
+++ b/probers/reboots.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#This script used only by linux/darwin
+day=$(date | awk {'print $1 " " $3 " " $2'})
+reboot_times=$(last reboot | grep "$day" | wc -l)
+echo "$reboot_times"

--- a/probers/reboots.sh
+++ b/probers/reboots.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 #This script used only by linux/darwin
-day=$(date | awk {'print $1 " " $3 " " $2'})
+day=$(date | awk {'print $1 " " $2 " " $3'})
 reboot_times=$(last reboot | grep "$day" | wc -l)
-echo "$reboot_times"
+echo $reboot_times

--- a/probers/reboots.sh
+++ b/probers/reboots.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 #This script used only by linux/darwin
 day=$(date | awk {'print $1 " " $2 " " $3'})
-reboot_times=$(last reboot | grep "$day" | wc -l)
-echo $reboot_times
+reboot_times=$(last reboot | grep -c "$day")
+echo "$reboot_times"


### PR DESCRIPTION
- Prompts system for number of reboots today and parses response
- Adds to Host Monitor report

tested on ubuntu VM with 2 system reboots today
<img width="258" alt="Screen Shot 2022-10-23 at 4 21 04 PM" src="https://user-images.githubusercontent.com/66742464/197418922-5252197b-55d9-4570-8729-ae6f139f0b91.png">

tested on mac, reboots.sh script and parser working
tested on mac for parsing
<img width="258" alt="Screen Shot 2022-10-23 at 4 18 07 PM" src="https://user-images.githubusercontent.com/66742464/197418923-25b89909-8b5c-4edb-aaac-e508ce4ac25f.png">

*** windows not yet tested